### PR TITLE
Fixed missing '}'

### DIFF
--- a/public/js/app/search/templates/search-list.html
+++ b/public/js/app/search/templates/search-list.html
@@ -15,7 +15,7 @@
             </div>
             <div class="row">
                 <div class="text-center">
-                    <div translate="FOUND_FOR" translate-compile translate-values="{total: '{{total}}', searchString: '{{searchString}}'"></div>
+                    <div translate="FOUND_FOR" translate-compile translate-values="{total: '{{total}}', searchString: '{{searchString}}'}"></div>
                 </div>
             </div>
             <div class="row continueShoppingBtn">

--- a/public/js/app/shared/directives/y-search.js
+++ b/public/js/app/shared/directives/y-search.js
@@ -28,7 +28,7 @@ angular.module('ds.ysearch', ['algoliasearch'])
     });
 
 angular.module('ds.ysearch')
-    .controller('ysearchController', ['$scope', '$rootScope', 'ysearchSvc', function (scope, $rootScope, ysearchSvc) {
+    .controller('ysearchController', ['$scope', '$rootScope', 'ysearchSvc', 'GlobalData', '$state', function (scope, $rootScope, ysearchSvc, GlobalData, $state) {
 
         if (!scope.page) {
             scope.page = 0;
@@ -78,6 +78,13 @@ angular.module('ds.ysearch')
                     scope.$digest();
                 }
             });
+
+        scope.keyPressed = function (event) {
+            if (event.which === 13) {
+                scope.hideSearchResults();
+                $state.go('base.search', { searchString: scope.search.text });
+            }
+        };
 
         scope.doSearch = function () {
             scope.search.showSearchResults = true;

--- a/public/js/app/shared/templates/ysearch.html
+++ b/public/js/app/shared/templates/ysearch.html
@@ -2,7 +2,7 @@
     <div class="right-inner-addon">
         <i ng-class="{'active': search.showSearchResults}" class="glyphicon glyphicon-search js-glyphicon"></i>
         <input id="search" autocomplete="off" placeholder="{{'SEARCH' | translate}}" type="text" ng-model="search.text"
-               ng-change="doSearch(search.text, search.page)" ng-focus="showSearchResults()"
+               ng-change="doSearch(search.text, search.page)" ng-focus="showSearchResults()" ng-keypress="keyPressed($event)"
                class="y-input form-control input-md"/>
     </div>
     <div class="y-search-container" ng-show="search.showSearchResults && search.results.length > 0">


### PR DESCRIPTION
Missing `}` generating parse/syntax errors while using the search feature.