### PR TITLE
Fixed npm warnings in package.json

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -282,7 +282,7 @@ We encourage contributions in the form of pull requests against the master branc
 
 ### License
  
-See the License.md file for complete license information.
+See the LICENSE file for complete license information.
 
 
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "grunt-contrib-jshint": "~0.7.1",
     "grunt-contrib-less": "^0.11.3",
     "grunt-contrib-uglify": "~0.2.7",
-    "grunt-contrib-watch": "0.5.3",
     "grunt-env": "latest",
     "grunt-express": "~1.3.5",
     "grunt-karma": "~2.0.0",
@@ -78,5 +77,9 @@
     "underscore": "^1.8.3"
   },
   "author": "hybris",
-  "license": "proprietary"
+  "license": "SEE LICENSE IN LICENSE",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sap/yaas-storefront"
+  }
 }


### PR DESCRIPTION
- Linked the license file
- Added the repository field
- Removed duplicate 'grunt-contrib-watch'

Made this based on the output of `npm install`:

```
npm WARN package.json caas-demo-store@0.0.1 No repository field.
npm WARN package.json caas-demo-store@0.0.1 license should be a valid SPDX license expression
npm WARN package.json Dependency 'grunt-contrib-watch' exists in both dependencies and devDependencies, using 'grunt-contrib-watch@0.5.3' from dependencies
npm WARN deprecated grunt-ngmin@0.0.3: use grunt-ng-annotate instead
npm WARN deprecated phantomjs@2.1.7: Package renamed to phantomjs-prebuilt. Please update 'phantomjs' package references to 'phantomjs-prebuilt'
npm WARN deprecated resemblejs@1.3.1: breaking interface change
npm WARN deprecated jade@1.3.1: Jade has been renamed to pug, please install the latest version of pug instead of jade
npm WARN engine grunt-json-minify@0.4.0: wanted: {"node":"~0.8.0"} (current: {"node":"4.4.3","npm":"2.15.1"})
npm WARN deprecated minimatch@0.3.0: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN deprecated minimatch@0.2.14: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN deprecated transformers@2.1.0: Deprecated, use jstransformer
npm WARN deprecated ngmin@0.4.1: use ng-annotate instead
npm WARN deprecated lodash@1.0.2: lodash@<3.0.0 is no longer maintained. Upgrade to lodash@^4.0.0.
npm WARN deprecated minimatch@2.0.10: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN deprecated tough-cookie@2.2.2: ReDoS vulnerability parsing Set-Cookie https://nodesecurity.io/advisories/130
npm WARN deprecated graceful-fs@1.2.3: graceful-fs v3.0.0 and before will fail on node releases >= v7.0. Please update to graceful-fs@^4.0.0 as soon as possible. Use 'npm ls graceful-fs' to find it in the tree.
npm WARN deprecated minimatch@0.4.0: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN deprecated lodash@2.4.1: lodash@<3.0.0 is no longer maintained. Upgrade to lodash@^4.0.0.
```