### PR TITLE
corrected SPDX license

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,5 +85,5 @@
     "underscore": "^1.8.3"
   },
   "author": "hybris",
-  "license": "proprietary"
+  "license": "LicenseRef-LICENSE"
 }


### PR DESCRIPTION
To prevent warning:

`npm WARN caas-demo-store@0.0.1 license should be a valid SPDX license expression`

see also: http://softwareengineering.stackexchange.com/questions/285885/which-spdx-license-is-equivalent-to-all-rights-reserved