### PR TITLE
remove warning:  "grunt-parallel" is missing

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   "devDependencies": {
     "grunt-contrib-watch": "^0.5.3",
     "grunt-json-minify": "^0.4.0",
+    "grunt-parallel": "^0.5.1",
     "istanbul": "0.3.0",
     "jasmine-reporters": "^1.0.0",
     "karma": "~0.13.22",


### PR DESCRIPTION
added   grunt-parallel to prevent missing warning.